### PR TITLE
DES-97: link to ADRs in individual repositories

### DIFF
--- a/DES/Accepted/Document-Evidence-Store-Frontend.md
+++ b/DES/Accepted/Document-Evidence-Store-Frontend.md
@@ -1,0 +1,3 @@
+# Document Evidence Store Frontend
+
+Architecture decision records for this project can be found under [document-evidence-store-frontend/docs/adr](https://github.com/LBHackney-IT/document-evidence-store-frontend/tree/main/docs/adr).

--- a/DES/Accepted/Documents-API.md
+++ b/DES/Accepted/Documents-API.md
@@ -1,0 +1,3 @@
+# Documents API
+
+Architecture decision records for this project can be found under [documents-api/docs/adr](https://github.com/LBHackney-IT/documents-api/tree/main/docs/adr).

--- a/DES/Accepted/Evidence-API.md
+++ b/DES/Accepted/Evidence-API.md
@@ -1,0 +1,3 @@
+# Evidence API
+
+Architecture decision records for this project can be found under [evidence-api/docs/adr](https://github.com/LBHackney-IT/evidence-api/tree/main/docs/adr).

--- a/DES/README.md
+++ b/DES/README.md
@@ -1,0 +1,3 @@
+# Document Evidence Service
+
+Here we have provided links to architecture decision records for the three repositories which make up the Document Evidence Service (DES).


### PR DESCRIPTION
We have decided to link _to_ each of our repositories which store the ADRs. We think this is preferable in our case because we have a number of repos and ensures that the documentation is close to the code.

Any thoughts are appreciated