### PR TITLE
Add links and docs to Social Care tools ADRs

### DIFF
--- a/SCT/README.md
+++ b/SCT/README.md
@@ -1,0 +1,11 @@
+# Social Care Tools
+
+Here we have provided links to ADR's specific to the [Social Care Tools applications](https://lbhackney-it.github.io/social-care-architecture/decisions/) (SCT).
+
+## Records
+
+### Accepted
+
+- [1. Record architecture decisions](https://lbhackney-it.github.io/social-care-architecture/decisions/record-architecture-decisions)
+- [2. Use ISO 8601 format for dates](https://lbhackney-it.github.io/social-care-architecture/decisions/use-iso-8601-format-for-dates)
+- [3. Prefer open source software](https://lbhackney-it.github.io/social-care-architecture/decisions/prefer-open-source-software)


### PR DESCRIPTION
Added a page to document and link the ADR's in the Social Care Tools project site.

The intent is that the SCT site will:

- Document decisions **_specific_** to the SCT project
- Maintain the varying SCT ADR's _with_ the SCT specific architecture documentation

Also see a [PR](https://github.com/LBHackney-IT/social-care-architecture/pull/26) in the SCT repo for linking to this repo.

Feedback is welcome.